### PR TITLE
Fix invalid syntax in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Casting to a specified type::
 Casting nested types::
 
     # Environment variable: FOO=1,2,3
-    foo = env('FOO'), subtype=int)
+    foo = env('FOO', subtype=int)
     # OR: foo = env('FOO', type=list, subtype=int)
     # Note that there is no way to implicitly call subtypes.
     assert foo == [1, 2, 3]


### PR DESCRIPTION
The provided code snippet has invalid syntax. Corrected it so that the syntax is valid.