### PR TITLE
Support dict as source + fix broken proxy support + allow getting all variables at once

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,33 @@ Type specific notes:
 * json: a regular JSON string such as ``FOO='{"foo": "bar"}'`` is expected.
 
 
+Environment Sources
+~~~~~~~~~~~~~~~~~~~
+By default, ``env`` uses ``os.environ`` as data source. Optionally, it can be
+re-populated with either a flat dict or a .env file.
+
+Read from dict:
+
+.. code-block:: python
+
+    vars = {'FOO': 42, 'BAR': 'baz'}
+    dict_env = env.from_env(vars)
+    dict_env.int('FOO')
+
+Read from a .env file (line delimited KEY=VALUE):
+
+.. code-block:: python
+
+    # This recurses up the directory tree until a file called '.env' is found.
+    file_env = env.from_envfile()
+
+    # Manually specifying a path
+    file_env = env.read_envfile('/config/.myenv')
+
+    # Values can be read as normal
+    file_env.int('FOO')
+
+
 Schemas
 ~~~~~~~
 Define a schema so you can only need to provide the cast, subcast, and defaults
@@ -165,22 +192,6 @@ An example of one might be returning a datastructure expected by a framework:
     redis_config = env('REDIS_URL', postprocessor=django_redis)
     assert redis_config == {'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': '127.0.0.1:6379:0', 'OPTIONS': {'PASSWORD': 'redispass'}}
-
-
-Environment File
-~~~~~~~~~~~~~~~~
-Read from a .env file (line delimited KEY=VALUE):
-
-.. code-block:: python
-
-    # This recurses up the directory tree until a file called '.env' is found.
-    env.read_envfile()
-
-    # Manually specifying a path
-    env.read_envfile('/config/.myenv')
-
-    # Values can be read as normal
-    env.int('FOO')
 
 
 Tests

--- a/envparse.py
+++ b/envparse.py
@@ -59,7 +59,7 @@ class Env(object):
 
     def __init__(self, **schema):
         self.schema = schema
-        self.env = os.environ
+        self._replace_env(os.environ)
 
     def __call__(self, var, default=NOTSET, cast=None, subcast=None,
                  force=False, preprocessor=None, postprocessor=None):
@@ -116,6 +116,9 @@ class Env(object):
         if postprocessor:
             value = postprocessor(value)
         return value
+
+    def _replace_env(self, new_env):
+        self.env = new_env
 
     def all(self):
         """
@@ -180,7 +183,7 @@ class Env(object):
         Load environment from the provided dict.
         :param env: A dict to use as the environment.
         """
-        self.env = env
+        self._replace_env(env)
         return self
 
     def from_envfile(self, path=None, **overrides):
@@ -215,7 +218,7 @@ class Env(object):
             return
 
         logger.debug('Reading environment variables from: %s', path)
-        self.env = {}
+        new_env = {}
         for line in content.splitlines():
             tokens = list(shlex.shlex(line, posix=True))
             # parses the assignment statement
@@ -228,11 +231,12 @@ class Env(object):
             if not re.match(r'[A-Za-z_][A-Za-z_0-9]*', name):
                 continue
             value = value.replace(r'\n', '\n').replace(r'\t', '\t')
-            self.env.setdefault(name, value)
+            new_env[name] = value
 
         for name, value in overrides.items():
-            self.env.setdefault(name, value)
+            new_env[name]
 
+        self._replace_env(new_env)
         return self
 
 # Convenience object if no schema is required.

--- a/envparse.py
+++ b/envparse.py
@@ -117,6 +117,14 @@ class Env(object):
             value = postprocessor(value)
         return value
 
+    def all(self):
+        """
+        Return a generator over all key-value pairs, parsing them on the fly.
+        """
+        keys = self.schema.keys() if self.schema else self.env.keys()
+        for key in keys:
+            yield (key, self.__call__(key))
+
     @classmethod
     def cast(cls, value, cast=str, subcast=None):
         """

--- a/envparse.py
+++ b/envparse.py
@@ -15,6 +15,10 @@ except ImportError:
     # Python 2
     import urlparse
 
+try:
+    basestring
+except NameError:
+    basestring = str
 
 __version__ = '0.2.0'
 
@@ -102,10 +106,9 @@ class Env(object):
                 value = default
 
         # Resolve any proxied values
-        if hasattr(value, 'startswith') and value.startswith('{{'):
-            value = self.__call__(value.lstrip('{{}}'), default, cast, subcast,
-                                  default, force, preprocessor, postprocessor)
-
+        if isinstance(value, basestring) and re.match(r"\{\{.+\}\}", value):
+            value = self.__call__(value.strip('{}'), default, cast, subcast,
+                                  force, preprocessor, postprocessor)
         if preprocessor:
             value = preprocessor(value)
         if value != default or force:

--- a/tests/envfile
+++ b/tests/envfile
@@ -13,3 +13,4 @@ DICT_STR=key1=val1, key2=val2
 DICT_INT=key1=1, key2=2
 JSON='{"foo": "bar", "baz": [1, 2, 3]}'
 URL=https://example.com/path?query=1
+REDIS_URL=redis://:redispass@127.0.0.1:6379/0

--- a/tests/test_envparse.py
+++ b/tests/test_envparse.py
@@ -133,8 +133,8 @@ def test_url(env):
     assert_type_value(url.__class__, url, env.url('URL'))
 
 
-def proxied_value(env):
-    assert_type_value(str, 'bar', env('PROXIED'))
+def test_proxied_value(env):
+    assert_type_value(str, 'foo', env('PROXIED'))
 
 
 def test_preprocessor(env):


### PR DESCRIPTION
#### Support dict as source

This is a feature I really missed - sometimes I want to have a local, optionally pre-modified version of os.environ or just some fake data to quickly test stuff. With the current approach, this would mean monkey-patching the global `os.environ`, potentially breaking other code relying on it.
- un-hardcode `os.environ`, it is now a default (but not sole) option for the inner `self.env` dict.
- `read_file` is now `from_file` and returns a modified `Env` object rather then messing with `os.environ`.
- `from_env` works the same way, but with a dict.
#### Fix broken proxy support

This had some weird broken code and a disabled test. All works as expected now.
#### Allow getting all variables at once

Just a little convenience method `all()` in case we just want to parse everything and use later.
#### Tests improvements

We now have each test running in either schema or schema-less mode, each mode in turn uses one of three data sources (`os.environ`, dict, file), so 6 fixtures for each test.
