### PR TITLE
Fixed logger name

### DIFF
--- a/envparse.py
+++ b/envparse.py
@@ -19,7 +19,7 @@ except ImportError:
 __version__ = '0.2.0'
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class ConfigurationError(Exception):


### PR DESCRIPTION
__file__ as a logger name doesn't allow to configure envparse logging externally.