### PR TITLE
Fix proxy values resolving

### DIFF
--- a/envparse.py
+++ b/envparse.py
@@ -103,7 +103,7 @@ class Env(object):
         # Resolve any proxied values
         if hasattr(value, 'startswith') and value.startswith('{{'):
             value = self.__call__(value.lstrip('{{}}'), default, cast, subcast,
-                                  default, force, preprocessor, postprocessor)
+                                  force, preprocessor, postprocessor)
 
         if preprocessor:
             value = preprocessor(value)


### PR DESCRIPTION
This fix TypeError:
TypeError: __call__() takes from 2 to 8 positional arguments but 9 were given

`default` argument passed twice to `__call__`

As i see this is already fixed in PR: #14 