### PR TITLE
Fix spelling error: s/MANDRILL_UESRNAME/MANDRILL_USERNAME/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ modify your app, you can simply make a configuration change:
 
 .. code-block:: bash
 
-    SMTP_LOGIN='{{MANDRILL_UESRNAME}}'
+    SMTP_LOGIN='{{MANDRILL_USERNAME}}'
 
 There are also a few convenience methods:
 


### PR DESCRIPTION
Noticed what is probably a small typo.