### PR TITLE
Feature/schema-env-processors-fix

### DIFF
--- a/envparse.py
+++ b/envparse.py
@@ -84,6 +84,10 @@ class Env(object):
                     subcast = params.get('subcast', subcast)
                 if default == NOTSET:
                     default = params.get('default', default)
+                if preprocessor is None:
+                    preprocessor = params.get('preprocessor', preprocessor)
+                if postprocessor is None:
+                    postprocessor = params.get('postprocessor', postprocessor)
             else:
                 if cast is None:
                     cast = params

--- a/tests/test_casts.py
+++ b/tests/test_casts.py
@@ -130,6 +130,13 @@ def test_dict_preprocessor(monkeypatch):
     
     assert_type_value(str, 'TEST_CASE', e('TEST'))
 
+def test_dict_postprocessor(monkeypatch):
+
+    monkeypatch.setenv('TEST', 'test')
+    e = Env(TEST=dict(cast=str, postprocessor=lambda x: x + "_case"))
+    
+    assert_type_value(str, 'test_case', e('TEST'))
+
 
 def test_postprocessor(monkeypatch):
     """

--- a/tests/test_casts.py
+++ b/tests/test_casts.py
@@ -123,6 +123,13 @@ def test_preprocessor():
     assert_type_value(str, 'FOO', env('STR', preprocessor=lambda
                                       v: v.upper()))
 
+def test_dict_preprocessor(monkeypatch):
+
+    monkeypatch.setenv('TEST', 'test_case')
+    e = Env(TEST=dict(cast=str, preprocessor=lambda x: x.upper()))
+    
+    assert_type_value(str, 'TEST_CASE', e('TEST'))
+
 
 def test_postprocessor(monkeypatch):
     """


### PR DESCRIPTION
This change enables a user to utilise a `preprocessor` or a `postprocessor` with the schema syntax. E.g.
```
test_env = Env(TEST=dict(cast=str, preprocessor=lambda v: v.upper()))
```

Prior to this, the pre/post processors would not fire, as they were not checked within the schema value. As such, the above code would show that the value of `test_env('TEST')` was `hello`, rather than `HELLO` if the processor had been applied. With this small addition, they now fire and work as I expected them too. I have added the accompanying tests too.

I hope this makes sense, feel free to make any alterations or comments as required.